### PR TITLE
Use the native django/postgres JSONField instead

### DIFF
--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import json
+from django.contrib.postgres.fields import JSONField
 import jsonfield
 import re
 
@@ -30,7 +31,7 @@ class AttributesFormField(JSONFormField):
         super(AttributesFormField, self).__init__(*args, **kwargs)
 
 
-class AttributesField(jsonfield.JSONField):
+class AttributesField(JSONField):
     """
     This is an opinionated sub-class of JSONField. Here's a summary of the
     primary differences:


### PR DESCRIPTION
This is unmergable at the moment, but if the database used is Postgresql > 9.4 the current code does not work without workarounds. 

See for example: https://bitbucket.org/schinckel/django-jsonfield/issues/53/typeerror-when-using-version-100-with

Also, according to https://bitbucket.org/schinckel/django-jsonfield it's recommended to use django.contrib.postgres if we're using Postgres. 

The below change works as expected on postgres, but there really should be some dynamic switching based on which database is used, however, I don't know how to code that. 
