### PR TITLE
dont use django-jsonfield

### DIFF
--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.utils.functional import curry
 from django.utils.html import mark_safe, conditional_escape
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.utils import six
 
 from .widgets import AttributesWidget
@@ -61,7 +61,7 @@ class AttributesField(models.Field):
         * The default widget is AttributesWidget from this package.
     """
     default_error_messages = {
-        'invalid': _("'%s' is not a valid JSON string.")
+        'invalid': ugettext_lazy("'%s' is not a valid JSON string.")
     }
     description = "JSON object"
 

--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -3,17 +3,16 @@
 from __future__ import unicode_literals
 
 import json
-import jsonfield
 import re
 
-from jsonfield.forms import JSONFormField
-
+from django import forms
 from django.core.validators import RegexValidator
 from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.db import models
 from django.utils.functional import curry
 from django.utils.html import mark_safe, conditional_escape
 from django.utils.translation import ugettext as _
-from django.utils.six import string_types
+from django.utils import six
 
 from .widgets import AttributesWidget
 
@@ -22,16 +21,31 @@ regex_key_validator = RegexValidator(regex=r'^[a-z][-a-z0-9_]*\Z',
                                      flags=re.IGNORECASE, code='invalid')
 
 
-class AttributesFormField(JSONFormField):
-    """
-    Sub-classed to set the default widget to AttributesWidget.
-    """
+class AttributesFormField(forms.CharField):
+    empty_values = [None, '']
+
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('widget', AttributesWidget)
         super(AttributesFormField, self).__init__(*args, **kwargs)
 
+    def to_python(self, value):
+        if isinstance(value, six.string_types) and value:
+            try:
+                return json.loads(value)
+            except ValueError as exc:
+                raise forms.ValidationError(
+                    'JSON decode error: %s' % (six.u(exc.args[0]),)
+                )
+        else:
+            return value
 
-class AttributesField(jsonfield.JSONField):
+    def validate(self, value):
+        # This is required in older django versions.
+        if value in self.empty_values and self.required:
+            raise forms.ValidationError(self.error_messages['required'], code='required')
+
+
+class AttributesField(models.Field):
     """
     This is an opinionated sub-class of JSONField. Here's a summary of the
     primary differences:
@@ -46,12 +60,28 @@ class AttributesField(jsonfield.JSONField):
           in a case-insensitive manner;
         * The default widget is AttributesWidget from this package.
     """
+    default_error_messages = {
+        'invalid': _("'%s' is not a valid JSON string.")
+    }
+    description = "JSON object"
+
     def __init__(self, *args, **kwargs):
+        if not kwargs.get('null', False):
+            kwargs['default'] = kwargs.get('default', dict)
         excluded_keys = kwargs.pop('excluded_keys', [])
         # Note we accept uppercase letters in the param, but the comparison
         # is not case sensitive. So, we coerce the input to lowercase here.
         self.excluded_keys = [key.lower() for key in excluded_keys]
         super(AttributesField, self).__init__(*args, **kwargs)
+        self.validate(self.get_default(), None)
+
+    def formfield(self, **kwargs):
+        defaults = {
+            'form_class': AttributesFormField,
+            'widget': AttributesWidget
+        }
+        defaults.update(**kwargs)
+        return super(AttributesField, self).formfield(**defaults)
 
     def from_db_value(self, value, expression, connection, context):
         """
@@ -61,51 +91,58 @@ class AttributesField(jsonfield.JSONField):
         """
         if value is None:
             return None
-        elif isinstance(value, string_types):
-            return json.loads(value, **self.decoder_kwargs)
+        elif isinstance(value, six.string_types):
+            return json.loads(value)
         else:
             return value
 
-    @classmethod
-    def to_str(cls, obj, field_name):
-        """
-        Emits stored attributes as a String suitable for for adding to an
-        HTML element and performs an outbound filter of excluded_keys.
-        """
-        # We are explicitly ignoring keys in `excluded_keys` here. The field
-        # itself prevents *new* keys from being created that are configured in the
-        # field parameter `excluded_keys`. This utility uses the same
-        # configuration to prevent any keys in `excluded_keys` from *existing*
-        # objects from being emitted.
+    def get_db_prep_value(self, value, connection=None, prepared=None):
+        return self.get_prep_value(value)
 
-        if not hasattr(obj, field_name):
-            raise ImproperlyConfigured(
-                _('"{field_name}" is not a field of {obj|r}').format(
-                    obj=obj, field_name=field_name))
+    def get_prep_value(self, value):
+        if value is None:
+            if not self.null and self.blank:
+                return ""
+            return None
+        return json.dumps(value)
 
-        opts = obj._meta
-        field = opts.get_field(field_name)
+    def get_prep_lookup(self, lookup_type, value):
+        if lookup_type in ["exact", "iexact", "in", "isnull"]:
+            return value
+        if lookup_type in ["contains", "icontains"]:
+            if isinstance(value, (list, tuple)):
+                raise TypeError("Lookup type %r not supported with argument of %s" % (
+                    lookup_type, type(value).__name__
+                ))
+            if isinstance(value, dict):
+                return self.get_prep_value(value)[1:-1]
+            return self.get_prep_value(value)
+        raise TypeError('Lookup type %r not supported' % lookup_type)
 
-        if not isinstance(field, cls):
-            raise TypeError(
-                _('"{field_name}" is not an AttributesField').format(
-                    field_name=field_name))
+    def get_default(self):
+        if self.has_default():
+            default = self.default
+            if callable(default):
+                default = default()
+            if isinstance(default, six.string_types):
+                return json.loads(default)
+            return json.loads(json.dumps(default))
+        return super(AttributesField, self).get_default()
 
-        excluded_keys = field.excluded_keys
-        value = getattr(obj, field_name)
-        try:
-            value_items = value.items()
-        except AttributeError:
-            value_items = [value]
+    def get_internal_type(self):
+        return 'TextField'
 
-        attrs = []
-        for key, val in value_items:
-            if key.lower() not in excluded_keys:
-                if val:
-                    attrs.append('{key}="{value}"'.format(key=key, value=conditional_escape(val)))
-                else:
-                    attrs.append('{key}'.format(key=key))
-        return mark_safe(" ".join(attrs))
+    def db_type(self, connection):
+        if connection.vendor == 'postgresql':
+            # Only do jsonb if in pg 9.4+
+            if connection.pg_version >= 90400:
+                return 'jsonb'
+            return 'text'
+        if connection.vendor == 'mysql':
+            return 'longtext'
+        if connection.vendor == 'oracle':
+            return 'long'
+        return 'text'
 
     def contribute_to_class(self, cls, name, **kwargs):
         """
@@ -120,7 +157,13 @@ class AttributesField(jsonfield.JSONField):
             setattr(cls, property_name, property(str_property))
 
     def validate(self, value, model_instance):
-        super(AttributesField, self).validate(value, model_instance)
+        if not self.null and value is None:
+            raise ValidationError(self.error_messages['null'])
+        try:
+            self.get_prep_value(value)
+        except ValueError:
+            raise ValidationError(self.error_messages['invalid'] % value)
+
         for key, val in value.items():
             self.validate_key(key)
             self.validate_value(key, val)
@@ -163,10 +206,46 @@ class AttributesField(jsonfield.JSONField):
                 _('The value for the key "{key}" is invalid. Please enter a '
                   'value that can be represented in JSON.').format(key=key))
 
-    def formfield(self, **kwargs):
-        defaults = {
-            'form_class': AttributesFormField,
-            'widget': AttributesWidget
-        }
-        defaults.update(**kwargs)
-        return super(AttributesField, self).formfield(**defaults)
+    def value_to_string(self, obj):
+        return self._get_val_from_obj(obj)
+
+    @classmethod
+    def to_str(cls, obj, field_name):
+        """
+        Emits stored attributes as a String suitable for for adding to an
+        HTML element and performs an outbound filter of excluded_keys.
+        """
+        # We are explicitly ignoring keys in `excluded_keys` here. The field
+        # itself prevents *new* keys from being created that are configured in the
+        # field parameter `excluded_keys`. This utility uses the same
+        # configuration to prevent any keys in `excluded_keys` from *existing*
+        # objects from being emitted.
+
+        if not hasattr(obj, field_name):
+            raise ImproperlyConfigured(
+                _('"{field_name}" is not a field of {obj|r}').format(
+                    obj=obj, field_name=field_name))
+
+        opts = obj._meta
+        field = opts.get_field(field_name)
+
+        if not isinstance(field, cls):
+            raise TypeError(
+                _('"{field_name}" is not an AttributesField').format(
+                    field_name=field_name))
+
+        excluded_keys = field.excluded_keys
+        value = getattr(obj, field_name)
+        try:
+            value_items = value.items()
+        except AttributeError:
+            value_items = [value]
+
+        attrs = []
+        for key, val in value_items:
+            if key.lower() not in excluded_keys:
+                if val:
+                    attrs.append('{key}="{value}"'.format(key=key, value=conditional_escape(val)))
+                else:
+                    attrs.append('{key}'.format(key=key))
+        return mark_safe(" ".join(attrs))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ CLASSIFIERS = [
 
 REQUIREMENTS = [
     'django>=1.8,<1.10',
-    'django-jsonfield>=1.0,<1.1',
 ]
 
 setup(


### PR DESCRIPTION
django-jsonfield and jsonfield both have the same package name and would cause bad conflicts when both are present in the python path.

I've moved the field logic from django-jsonfield into the `AttributesField`