### PR TITLE
Stopped forcing jsonb field on postgresql backends

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+0.1.0 (2016-06-29)
+------------------
+
+* Stop forcing Django to use `jsonb` fields on PostgreSQL backends
+
+
 0.0.6 (2016-06-27)
 ------------------
 

--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -132,18 +132,6 @@ class AttributesField(models.Field):
     def get_internal_type(self):
         return 'TextField'
 
-    def db_type(self, connection):
-        if connection.vendor == 'postgresql':
-            # Only do jsonb if in pg 9.4+
-            if connection.pg_version >= 90400:
-                return 'jsonb'
-            return 'text'
-        if connection.vendor == 'mysql':
-            return 'longtext'
-        if connection.vendor == 'oracle':
-            return 'long'
-        return 'text'
-
     def contribute_to_class(self, cls, name, **kwargs):
         """
         Adds a @property: «name»_str that returns a string representation of


### PR DESCRIPTION
Simply removes the `db_type` method from the field. It was here that the `jsonb` field type was being forced for postgresql v9.4+ backends.

Steps taken to test:
1. Create new blank project in Aldryn (did not deploy though);
2. On local machine: aldryn project setup attributes-test;
3. Verify that DB has 'jsonb' field in django dbshell. Results:
````
db=# SELECT table_name, column_name, data_type FROM information_schema.columns WHERE data_type='jsonb';

            table_name            |   column_name   | data_type 

----------------------------------+-----------------+-----------

 cmsplugin_filer_file_filerfile   | link_attributes | jsonb

 cmsplugin_filer_image_filerimage | link_attributes | jsonb

 djangocms_link_link              | attributes      | jsonb

(3 rows)
````
Steps continued:
4. Added branch of 'djangocms-attributes-field' to requirements.in;
5. `aldryn project update`;
6. `aldryn project up`;
7. Verify DB still has 'jsonb' fields; **It does.**
8. Verify project still works as expected; **It does.**
