### PR TITLE
Fixed a bug with multiple widgets on the same page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+0.1.2 (unreleased)
+------------------
+
+* Fixed a bug with multiple widgets on the same page
+
+
 0.1.1 (2016-07-12)
 ------------------
 

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -149,6 +149,13 @@ class AttributesWidget(Widget):
                 $(function () {
                     $('.djangocms-attributes-field').each(function () {
                         var that = $(this);
+
+                        if (that.data('isAttributesFieldInitialized')) {
+                            return;
+                        }
+
+                        that.data('isAttributesFieldInitialized', true);
+
                         var emptyRow = that.find('.template');
                         var btnAdd = that.find('.add-attributes-pair');
                         var btnDelete = that.find('.delete-attributes-pair');


### PR DESCRIPTION
Every time widget was included it would attach the handlers, so when
user would add a new key value pair it would add the amount of pairs
equal to the amount of fields on the page.