### PR TITLE
Remove "Key" and "Value" labels on widget

### DIFF
--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -37,11 +37,9 @@ class AttributesWidget(Widget):
         template = """
         <div class="form-row attributes-pair">
             <div class="field-box">
-               <label>Key</label>
                <input type="text" class="attributes-key" name="attributes_key[{field_name}]" value="{key}" {key_attrs}>
             </div>
             <div class="field-box">
-               <label>Value</label>
                <input type="text" class="attributes-value"
                       name="attributes_value[{field_name}]"
                       value="{value}" {val_attrs}>

--- a/test_settings.py
+++ b/test_settings.py
@@ -11,5 +11,6 @@ def run():
     from djangocms_helper import runner
     runner.run('djangocms_attributes_field')
 
+
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
They don't add much to the very obvious context and are hard to translate meaningfully.