### PR TITLE
WiP: Add support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
-# Without this, we cannot test Py35
-python: 3.5
+# Without this, we cannot test Py36
+python: 3.6
 
 # Use container based infrastructure
 sudo: false
@@ -10,12 +10,19 @@ env:
   matrix:
     - TOXENV=flake8
 
+    - TOXENV=py36-dj11
+    - TOXENV=py35-dj11
+    - TOXENV=py34-dj11
+    - TOXENV=py27-dj11
+    - TOXENV=py36-dj10
     - TOXENV=py35-dj10
     - TOXENV=py34-dj10
     - TOXENV=py27-dj10
+    - TOXENV=py36-dj19
     - TOXENV=py35-dj19
     - TOXENV=py34-dj19
     - TOXENV=py27-dj19
+    - TOXENV=py36-dj18
     - TOXENV=py35-dj18
     - TOXENV=py34-dj18
     - TOXENV=py33-dj18

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -3,7 +3,10 @@
 from __future__ import unicode_literals
 
 from django.forms import Widget
-from django.forms.widgets import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.widgets import flatatt
 from django.utils.html import escape, strip_spaces_between_tags
 from django.utils.text import mark_safe
 from django.utils.translation import ugettext as _

--- a/test_requirements/django-1.11.txt
+++ b/test_requirements/django-1.11.txt
@@ -1,0 +1,2 @@
+-r base.txt
+Django>=1.11,<2.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
     flake8,
-    py{35,34,27}-dj10,
-    py{35,34,27}-dj19,
-    py{35,34,33,27}-dj18,
+    py{36,35,34,27}-dj11,
+    py{36,35,34,27}-dj10,
+    py{36,35,34,27}-dj19,
+    py{36,35,34,33,27}-dj18,
 
 skip_missing_interpreters = True
 
@@ -12,6 +13,7 @@ deps =
     dj18: -rtest_requirements/django-1.8.txt
     dj19: -rtest_requirements/django-1.9.txt
     dj10: -rtest_requirements/django-1.10.txt
+    dj11: -rtest_requirements/django-1.11.txt
 commands =
     {envpython} --version
     - coverage erase


### PR DESCRIPTION
This fixes an import on Django 1.11 and adds configuration to run tox on that version

Code must still be ported to new widget rendering API