### PR TITLE
Fixed #21 : key:value pairs not saved to database

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+0.2.1 (unreleased)
+------------------
+
+* Fixed a bug (key:value) pairs not saved to database with Django 1.10
+
 0.2.0 (2017-02-28)
 ------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@
 
 * Fixed a bug (key:value) pairs not saved to database with Django 1.10
 
+
 0.2.0 (2017-02-28)
 ------------------
 

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -198,3 +198,6 @@ class AttributesWidget(Widget):
             values = data.getlist(val_field)
             return dict([item for item in zip(keys, values) if not item[0] == ''])
         return {}
+
+    def value_omitted_from_data(self, data, files, name):
+        return False


### PR DESCRIPTION
The attributes works well with django 1.8 and 1.9 but did not work with django 1.10 